### PR TITLE
Change GitHub action to manually build using yarn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build/release
 on:
   push:
     branches:
-      - main
+      - gh-actions-test
 
 jobs:
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,19 +22,8 @@ jobs:
         with:
           node-version: 14
           
-      - name: directory
-        shell: bash
-        run: |
-          cd ../../
-
-      - name: Build/release Electron app
-        uses: michalzaq12/action-electron-nuxt@v1
-        with:
-          # GitHub token, automatically provided to the action
-          # (No need to define this secret in the repo settings)
-          # type: string
-          github_token: ${{ secrets.github_token }}
-
-          # If the commit is tagged with a version (e.g. "v1.0.0")
-          # type: boolean
-          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Build
+        run: yarn build
+            

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Build
+        env:
+          GH_TOKEN: ${{ secrets.github_token }}
         run: yarn build
             


### PR DESCRIPTION
The pre-made action for electron builder did not work, so this is a simple and straightforward manual approach